### PR TITLE
fix: replace 3 bare excepts with except Exception

### DIFF
--- a/hy3dshape/models/autoencoders/inference_utils/extract_geometry_fast_v2.py
+++ b/hy3dshape/models/autoencoders/inference_utils/extract_geometry_fast_v2.py
@@ -200,7 +200,7 @@ class FastGeometryExtractorV2(BaseGeometryExtractor):
                     try:
                         from diso import DiffDMC
                         self.dmc = DiffDMC(dtype=torch.float32).to(self.device)
-                    except:
+                    except Exception:
                         raise ImportError("Please install diso via `pip install diso`, or set mc_algo to 'mc'")
 
                 torch.cuda.empty_cache()

--- a/hy3dshape/models/autoencoders/inference_utils/extract_geometry_vanilla.py
+++ b/hy3dshape/models/autoencoders/inference_utils/extract_geometry_vanilla.py
@@ -124,7 +124,7 @@ class VanillaGeometryExtractor(BaseGeometryExtractor):
                     try:
                         from diso import DiffDMC
                         self.dmc = DiffDMC(dtype=torch.float32).to(self.device)
-                    except:
+                    except Exception:
                         raise ImportError("Please install diso via `pip install diso`, or set mc_algo to 'mc'")
                 octree_resolution = 2 ** octree_depth if octree_resolution is None else octree_resolution
                 sdf = grid_logits[0] / octree_resolution

--- a/hy3dshape/models/diffusion/transport/integrators.py
+++ b/hy3dshape/models/diffusion/transport/integrators.py
@@ -56,7 +56,7 @@ class sde:
 
         try:
             sampler = sampler_dict[self.sampler_type]
-        except:
+        except Exception:
             raise NotImplementedError("Smapler type not implemented.")
     
         return sampler


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 3 files.

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`. `except Exception:` preserves fallback behavior while allowing system exceptions to propagate.

**Files:** `extract_geometry_fast_v2.py`, `extract_geometry_vanilla.py`, `integrators.py`